### PR TITLE
Add .gitignore for Python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environment variables
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Data files (optional - uncomment if you don't want to track large CSV files)
+# *.csv 


### PR DESCRIPTION
Adding comprehensive .gitignore file for Python projects.

- Excludes Python cache files and compiled code
- Ignores Jupyter notebook checkpoints
- Excludes virtual environment directories
- Ignores IDE-specific files (.vscode, .idea)
- Excludes OS-specific files (.DS_Store, Thumbs.db)
- Improves repository cleanliness and reduces noise